### PR TITLE
Fix/windows run scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "db64",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "db64",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
         "d": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "require": "./dist/db64.cjs"
   },
   "scripts": {
-    "test": "./node_modules/.bin/http-server -p=3333 --s | ./node_modules/.bin/mocha-chrome http://127.0.0.1:3333/test/db64.test.html --ignore-exceptions",
-    "tester": "./node_modules/.bin/http-server -a 127.0.0.1 -p 2222 -o",
-    "lint": "./node_modules/.bin/eslint --fix ./src ./create-distribution.js ./examples ./test",
-    "d": "./node_modules/.bin/http-server -o",
+    "test": "npx http-server -p=3333 --s | npx mocha-chrome http://127.0.0.1:3333/test/db64.test.html --ignore-exceptions",
+    "tester": "npx http-server -a 127.0.0.1 -p 2222 -o",
+    "lint": "npx eslint --fix ./src ./create-distribution.js ./examples ./test",
+    "d": "npx http-server -o",
     "prepublishOnly": "node create-distribution.js"
   },
   "repository": {


### PR DESCRIPTION
Hello !

I made some changes in the package.json to call the script commands because I couldn't get them to work with Git bash for Windows.

You can see these errors in the screenshots below.

Impossible to run each of the scripts due to files being called with the "./" prefix :
![db64-cant-run-scripts](https://github.com/julienetie/db64/assets/46821774/b359a1e8-2a20-4e9c-80b2-4eb0687b66a2)


I also made some changes to the create-distribution.js file, which I couldn't get to work either.

As you can see, the variable currentFilePath = path.dirname returned the wrong value with two iterations of my "C:" folder :
![db64-create-distribution-path-error](https://github.com/julienetie/db64/assets/46821774/8605e6c5-50de-4b7b-8f87-66044d1a39c1)

Also, once I'd corrected the path, I kept getting the same ENOENT error because the "/dist" folder didn't exist : 
![db64-cant-run-create-distribution-if-dist-repo-doesnt-exist](https://github.com/julienetie/db64/assets/46821774/88b8ff5a-4a72-4309-be33-69fc5a07da4c)

Then, as another command was called by the "./node_modules" prefix, I was unable to launch the script as I had done with the package.json scripts : 
![db64-cant-run-create-distribution-without-npx](https://github.com/julienetie/db64/assets/46821774/9feb7dc9-c9fa-4332-8cfa-8fe84d6207d3)

And here's the screenshot after the modifications : 
![db64-success-run-create-distribution-after-changes](https://github.com/julienetie/db64/assets/46821774/4955c10b-3d98-4409-86be-0e559055fe28)


Thank you for your work !